### PR TITLE
fix: Add required headers for Lambda extension auth and KMS decryption

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dwkerwin/ssm-config",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A config loader for environment variables, AWS SSM parameters, and static fallbacks, optimized for AWS Lambda with Extensions API support.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When using the AWS Parameters and Secrets Lambda Extension, requests to
localhost:2773 require two critical headers:
- AWS_SESSION_TOKEN in X-Aws-Parameters-Secrets-Token for extension auth
- KMS key ID in X-Aws-Kms-Key-Id for SecureString parameter decryption

This fixes the 401 unauthorized error when accessing parameters through
the extension endpoint while maintaining the ability to fall back to
direct SSM API calls if needed.

- Added AWS_SESSION_TOKEN header to all Lambda extension requests
- Added X-Aws-Kms-Key-Id header when KMS key ID is provided
- Maintains existing fallback behavior to direct SSM API calls