### PR TITLE
fix: URL encode parameter names for Lambda extension requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,9 @@ const ssmClient = new SSMClient({ region: process.env.AWS_REGION });
 
 // Helper function to fetch from Lambda extension via localhost:2773
 async function getFromLambdaExtension(parameterName, kmsKeyId = null) {
-  const endpoint = `http://localhost:2773/systemsmanager/parameters/get?name=${parameterName}&withDecryption=true`;
+  // URL encode the parameter name
+  const encodedName = encodeURIComponent(parameterName);
+  const endpoint = `http://localhost:2773/systemsmanager/parameters/get?name=${encodedName}&withDecryption=true`;
   const headers = {
     'X-Aws-Parameters-Secrets-Token': process.env.AWS_SESSION_TOKEN
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dwkerwin/ssm-config",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A config loader for environment variables, AWS SSM parameters, and static fallbacks, optimized for AWS Lambda with Extensions API support.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When using the AWS Parameters and Secrets Lambda Extension, parameter paths
must be URL encoded to handle special characters like forward slashes.
For example, '/vm/secrets/jwt_secret' needs to be encoded as
'%2Fvm%2Fsecrets%2Fjwt_secret'.

- Added encodeURIComponent() to properly encode parameter names
- Fixes 400 Bad Request errors when accessing parameters via Lambda extension
- Maintains existing headers for auth and KMS decryption