### PR TITLE
feat: enhance config initialization to handle concurrency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dwkerwin/ssm-config",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A config loader for environment variables, AWS SSM parameters, and static fallbacks, optimized for AWS Lambda with Extensions API support.",
   "main": "index.js",
   "scripts": {

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -218,4 +218,27 @@ describe('SSM Config', () => {
       .rejects
       .toThrow('Configuration map not set');
   });
+
+  test('should handle concurrent initializations with a single SSM call', async () => {
+    const config = require('../index');
+    
+    // Set up config with an SSM parameter
+    config.configMap = {
+      TEST_KEY: { 
+        envVar: 'TEST_VALUE', 
+        fallbackSSM: TEST_CONFIG.PARAMS.STRING_PARAM,
+        type: 'string' 
+      }
+    };
+
+    // Start multiple concurrent initializations
+    const [result1, result2, result3] = await Promise.all([
+      config.initializeConfig(),
+      config.initializeConfig(),
+      config.initializeConfig()
+    ]);
+
+    // Verify the config was loaded correctly
+    expect(config.TEST_KEY).toBe('test-string-value');
+  });
 });


### PR DESCRIPTION
- Introduced a promise-based mechanism to ensure only one initialization occurs at a time, preventing multiple SSM calls.
- Updated the `initializeConfig` function to return an existing promise if initialization is already in progress.
- Enhanced documentation in README to clarify usage patterns and initialization safety.
- Bumped package version to 1.0.4 to reflect these changes.
- Added tests to verify concurrent initialization behavior.

This update improves the library's usability in applications where multiple components may attempt to initialize the configuration simultaneously.