### PR TITLE
fix: handle mixed encrypted/unencrypted SSM parameters with custom KMS…

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,9 +55,9 @@ async function getParameterFromSSM(parameterName, kmsKeyId = null) {
     WithDecryption: true
   };
 
-  if (kmsKeyId) {
-    params.KeyId = kmsKeyId;
-  }
+  // Don't set KeyId - let AWS handle the decryption automatically
+  // If the parameter is encrypted, AWS will use the appropriate key
+  // If it's not encrypted, AWS will return the plain text value
 
   try {
     const command = new GetParameterCommand(params);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dwkerwin/ssm-config",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A config loader for environment variables, AWS SSM parameters, and static fallbacks, optimized for AWS Lambda with Extensions API support.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
…S key

Remove KeyId parameter from GetParameterCommand when fetching individual parameters. AWS SSM automatically handles decryption for encrypted parameters and returns plain text for unencrypted ones. Previously, passing KeyId to unencrypted parameters caused silent failures when using custom KMS keys.